### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/sstoyanov0194/1d089ae6-3ad1-4546-b755-3c1b497c6137/62ea0345-1140-4b8d-8fdc-d23f2069729e/_apis/work/boardbadge/8206511f-1898-46b2-a2aa-bd4e4a5082aa)](https://dev.azure.com/sstoyanov0194/1d089ae6-3ad1-4546-b755-3c1b497c6137/_boards/board/t/62ea0345-1140-4b8d-8fdc-d23f2069729e/Microsoft.RequirementCategory)
 # Bulconn
 Company site


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/sstoyanov0194/1d089ae6-3ad1-4546-b755-3c1b497c6137/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.